### PR TITLE
Fix pluralization of name usage command

### DIFF
--- a/cmdg_nameusage.py
+++ b/cmdg_nameusage.py
@@ -240,7 +240,7 @@ class NameUsage(commands.GroupCog, name="nameusage",description="Get data about 
                 elif name.lower() in member.name.lower():
                     count += 1
             type_string = "username or nickname"
-        await itx.followup.send(f"I found {count} people with '{name.lower()}' in their {type_string}",ephemeral=not public)
+        await itx.followup.send(f"I found {count} {"person" if count == 1 else "people"} with '{name.lower()}' in their {type_string}",ephemeral=not public)
 
 async def setup(client):
     await client.add_cog(NameUsage(client))


### PR DESCRIPTION
- name usage command says "1 people" if exactly 1 person has the searched name, this fixes that