### PR TITLE
Migrate from blocking "requests" to async "aiohttp"

### DIFF
--- a/extensions/addons/cogs/otheraddons.py
+++ b/extensions/addons/cogs/otheraddons.py
@@ -297,9 +297,8 @@ class OtherAddons(commands.Cog):
                 "appid": itx.client.api_tokens['Open Exchange Rates'],
                 "show_alternative": "true",
             }
-            async with aiohttp.ClientSession() as client:
-                async with client.get("https://openexchangerates.org/api/latest.json", params=params) as response:
-                    data = await response.json()
+            async with aiohttp.ClientSession() as client, client.get("https://openexchangerates.org/api/latest.json", params=params) as response:
+                data = await response.json()
             if data.get("error", 0):
                 await itx.response.send_message(
                     "I'm sorry, something went wrong while trying to get "

--- a/extensions/addons/cogs/otheraddons.py
+++ b/extensions/addons/cogs/otheraddons.py
@@ -1,6 +1,6 @@
 import json  # to read API json responses
-import requests  # to read api calls
 
+import aiohttp
 import discord
 import discord.app_commands as app_commands
 import discord.ext.commands as commands
@@ -297,11 +297,9 @@ class OtherAddons(commands.Cog):
                 "appid": itx.client.api_tokens['Open Exchange Rates'],
                 "show_alternative": "true",
             }
-            response_api = requests.get(
-                "https://openexchangerates.org/api/latest.json",
-                params=params
-            ).text
-            data = json.loads(response_api)
+            async with aiohttp.ClientSession() as client:
+                async with client.get("https://openexchangerates.org/api/latest.json", params=params) as response:
+                    data = await response.json()
             if data.get("error", 0):
                 await itx.response.send_message(
                     "I'm sorry, something went wrong while trying to get "

--- a/extensions/addons/cogs/searchaddons.py
+++ b/extensions/addons/cogs/searchaddons.py
@@ -376,9 +376,8 @@ class SearchAddons(commands.Cog):
             "apiKey": equaldex_key,
             # "formatted": "true",
         }
-        async with aiohttp.ClientSession() as client:
-            async with client.get("https://www.equaldex.com/api/region", params=querystring) as response:
-                response_api = await response.text()
+        async with aiohttp.ClientSession() as client, client.get("https://www.equaldex.com/api/region", params=querystring) as response:
+            response_api = await response.text()
         # returns ->  <pre>{"regions":{...}}</pre>  <- so you need to
         #  remove the <pre> and </pre> parts. It also has some
         #  <br \/>\r\n strings in there for some reason...? so uh
@@ -504,9 +503,8 @@ class SearchAddons(commands.Cog):
             "output": "json",
         }
         try:
-            async with aiohttp.ClientSession() as client:
-                async with client.get("https://api.wolframalpha.com/v2/query", params=params) as response:
-                    api_response: WolframResult = await response.json()
+            async with aiohttp.ClientSession() as client, client.get("https://api.wolframalpha.com/v2/query", params=params) as response:
+                api_response: WolframResult = await response.json()
         except (aiohttp.client_exceptions.ContentTypeError, json.JSONDecodeError):
             await itx.followup.send(
                 "Your input gave a malformed result! Perhaps it took "

--- a/extensions/addons/cogs/searchaddons.py
+++ b/extensions/addons/cogs/searchaddons.py
@@ -1,6 +1,7 @@
 import json  # to read API json responses
 
-import requests  # to read api calls
+import aiohttp # to read api calls
+import aiohttp.client_exceptions
 
 import discord
 import discord.app_commands as app_commands
@@ -375,11 +376,9 @@ class SearchAddons(commands.Cog):
             "apiKey": equaldex_key,
             # "formatted": "true",
         }
-        response = requests.get(
-            "https://www.equaldex.com/api/region",
-            params=querystring
-        )
-        response_api = response.text
+        async with aiohttp.ClientSession() as client:
+            async with client.get("https://www.equaldex.com/api/region", params=querystring) as response:
+                response_api = await response.text()
         # returns ->  <pre>{"regions":{...}}</pre>  <- so you need to
         #  remove the <pre> and </pre> parts. It also has some
         #  <br \/>\r\n strings in there for some reason...? so uh
@@ -505,11 +504,10 @@ class SearchAddons(commands.Cog):
             "output": "json",
         }
         try:
-            api_response: WolframResult = requests.get(
-                "https://api.wolframalpha.com/v2/query",
-                params=params
-            ).json()
-        except requests.exceptions.JSONDecodeError:
+            async with aiohttp.ClientSession() as client:
+                async with client.get("https://api.wolframalpha.com/v2/query", params=params) as response:
+                    api_response: WolframResult = await response.json()
+        except (aiohttp.client_exceptions.ContentTypeError, json.JSONDecodeError):
             await itx.followup.send(
                 "Your input gave a malformed result! Perhaps it took "
                 "too long to calculate...",

--- a/extensions/staffaddons/cogs/staffaddons.py
+++ b/extensions/staffaddons/cogs/staffaddons.py
@@ -170,10 +170,8 @@ class StaffAddons(commands.Cog):
     async def get_bot_version(self, itx: discord.Interaction[Bot]):
         # get most recently pushed bot version
         # noinspection LongLine
-        async with aiohttp.ClientSession() as client:
-            # noqa
-            async with client.get("https://raw.githubusercontent.com/TransPlace-Devs/uncute-rina/main/main.py") as response:
-                latest_rina = await response.text()
+        async with aiohttp.ClientSession() as client, client.get("https://raw.githubusercontent.com/TransPlace-Devs/uncute-rina/main/main.py") as response:
+            latest_rina = await response.text()
         latest_version = (latest_rina
                           .split("BOT_VERSION = \"", 1)[1]
                           .split("\"", 1)[0])

--- a/extensions/staffaddons/cogs/staffaddons.py
+++ b/extensions/staffaddons/cogs/staffaddons.py
@@ -1,8 +1,7 @@
 from datetime import datetime, timedelta
 # ^ for /delete_week_selfies (within 7 days), and /version startup
 #  time parsing to discord unix <t:1234:F>
-import requests
-# to fetch from GitHub and see Rina is running the latest version
+import aiohttp # to fetch from GitHub and see Rina is running the latest version
 
 import discord
 import discord.app_commands as app_commands
@@ -171,9 +170,10 @@ class StaffAddons(commands.Cog):
     async def get_bot_version(self, itx: discord.Interaction[Bot]):
         # get most recently pushed bot version
         # noinspection LongLine
-        latest_rina = requests.get(
-            "https://raw.githubusercontent.com/TransPlace-Devs/uncute-rina/main/main.py"  # noqa
-        ).text
+        async with aiohttp.ClientSession() as client:
+            # noqa
+            async with client.get("https://raw.githubusercontent.com/TransPlace-Devs/uncute-rina/main/main.py") as response:
+                latest_rina = await response.text()
         latest_version = (latest_rina
                           .split("BOT_VERSION = \"", 1)[1]
                           .split("\"", 1)[0])

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,5 @@ pymongo>=4.14.0
 pandas>=2.3.1
 apscheduler>=3.11.0
 matplotlib>=3.10.5
-requests>=2.32.3
 pytest>=8.4.1
 aiohttp>=3.12.15


### PR DESCRIPTION
TL;DR: Made it so that hard maths problems do not disable ban appeals

I've moved all the blocking `requests` usages with `aiohttp`, which means that web requests will not freeze the entire bot while it waits for a response.

To ensure that this doesn't happen again, I've removed `requests` from `requirements.txt`