### PR TITLE
replace imgur with raw github links

### DIFF
--- a/extensions/tags/tags.py
+++ b/extensions/tags/tags.py
@@ -184,7 +184,7 @@ def create_report_info_tag(
         color=(255, 0, 0),
         report_to_staff=True,
     )
-    tag.embed.set_image(url="https://i.imgur.com/jxEcGvl.gif")
+    tag.embed.set_image(url="https://raw.githubusercontent.com/TransGG/assets/refs/heads/main/how-to-report.gif")
     return tag
 
 


### PR DESCRIPTION
imgur doesn't work in the UK and our servers are in the UK. although none of these changes are strictly necessary, it makes sense to "self-host" (as in, in our github organization) these asset files anyway